### PR TITLE
Change Version in plugin description

### DIFF
--- a/bp-group-activities-notifier.php
+++ b/bp-group-activities-notifier.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://buddydev.com/plugins/bp-group-activities-notifier/
  * Author: BuddyDev Team
  * Author URI: https://buddydev.com
- * Version: 1.0.3
+ * Version: 1.0.4
  * Description: Notifies on any action in the group to all group members. I have tested with group join, group post update, forum post/reply. Should work with others too
  */
 


### PR DESCRIPTION
I don't understand why it differ from the release, maybe it's an oversight ?